### PR TITLE
Fix spectating games in Safari

### DIFF
--- a/frontend/prebuild/src/app/login/login.component.ts
+++ b/frontend/prebuild/src/app/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, NgZone } from '@angular/core';
 import { Router } from '@angular/router';
 
 import * as $ from 'jquery';
@@ -9,7 +9,7 @@ import * as $ from 'jquery';
   styleUrls: ['./login.component.css']
 })
 export class LoginComponent implements OnInit {
-  constructor(private router: Router) {
+  constructor(private router: Router, private ngZone: NgZone) {
 
   }
 
@@ -31,11 +31,14 @@ export class LoginComponent implements OnInit {
     // TODO: update the button on click to indicate a waiting state in case
     // this post request takes a noticeable amount of time
     let router = this.router;
+    let ngZone = this.ngZone;
     $.post(`http://${document.location.hostname}:8080/round/create`, function(data) {
       console.log(`Created round with id=${data}`);
       sessionStorage.setItem('isSpectator', 'true');
       sessionStorage.setItem('roundId', data);
-      router.navigate(['/game']);
+      ngZone.run(() => {
+        router.navigate(['/game']);
+      });
     });
   }
 }


### PR DESCRIPTION
Spectating games doesn't work in Safari because the ngOnInit doesn't fire when hostGame() tells the router to navigate to the GameComponent.

Explanation: https://stackoverflow.com/questions/35936535/angular-2-ngoninit-not-called#comment59531723_35937062

I have no idea why Chrome works, but not Safari. But it makes sense that we would need to do this, since jQuery's invocation of the callback would likely come from outside Angular's zone so we'd need to force the navigation back into it.