### PR TITLE
Mechanism for prod deployments

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -53,7 +53,16 @@ task npmUpdate {
 task buildStandaloneClient(type: NpmTask, dependsOn: npmInstall) {
     group 'build client'
     description = 'Compile client side folder for development'
-    args = ['run', 'build']
+    if("prod".equals(System.getProperty("env_mode"))) {
+        println "### prod environment ###"
+        file("${rootDir}/frontend/prebuild/src/environments/environment.prod.ts").eachLine { String line ->
+            println line
+        }
+        println "########################"
+        args = ['run', 'prod']
+    } else {
+        args = ['run', 'build']
+    }
 }
 
 task copyFrontend(type: Copy) {

--- a/frontend/prebuild/src/environments/.gitignore
+++ b/frontend/prebuild/src/environments/.gitignore
@@ -1,0 +1,2 @@
+# Do not check in the production environment files
+environment.prod.ts

--- a/frontend/prebuild/src/environments/environment.prod.ts
+++ b/frontend/prebuild/src/environments/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true
-};


### PR DESCRIPTION
Allow a mechanism for use to override environment variables on production builds, for example:

```bash
$ echo "export const environment = {\
  production: true,\
  API_URL_GAME_ROUND: 'http://game-service.com/round',\
  API_URL_GAME_WS: 'ws://game-service.com/round/ws',\
  API_URL_PLAYERS: 'http://player-service.com/player'\
};" > ./frontend/prebuild/src/environments/environment.prod.ts
```

Then, the repository can be built with:
`./gradlew build -Denv_mode=prod`