### PR TITLE
Controls page theme

### DIFF
--- a/frontend/prebuild/src/app/controls/controls.component.html
+++ b/frontend/prebuild/src/app/controls/controls.component.html
@@ -2,10 +2,10 @@
   <h1>Liberty Bikes</h1>
 </div>
 <div id="game-buttons" class="navbar">
-  <button type="button" class="btn btn-success" (click)="startGame()">Start Game</button>
-  <button type="button" class="btn btn-info" (click)="requeue()">Requeue</button>
+  <button type="button" (click)="startGame()">Start Game</button>
+  <button type="button" (click)="requeue()">Requeue</button>
 </div>
-<div id="controller">
+<div id="controller" [style.height.px]="windowHeight">
   <canvas id="dpad-canvas" width="800" height="800"></canvas>
 </div>
 

--- a/frontend/prebuild/src/app/controls/controls.component.scss
+++ b/frontend/prebuild/src/app/controls/controls.component.scss
@@ -1,4 +1,4 @@
-$titlebar: 50px;
+$titlebar: 60px;
 $navbar-border: 1px solid #ccc;
 
 body {
@@ -7,15 +7,14 @@ body {
 }
 
 :host {
-  display: grid;
-  grid-template-rows: $titlebar $titlebar 1fr;
-  grid-template-columns: 1fr;
-
-  height: 100vh;
+  position: fixed;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
 }
 
 .navbar {
-  background-color: #eee;
+  background-color: rgba(0, 0, 0, 0.2);
 
   height: $titlebar;
 
@@ -25,56 +24,64 @@ body {
   padding: 0px 5px;
 }
 
-.navbar h1 {
-  margin: 0px;
+#titlebar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+
+  justify-content: center;
 }
 
-#titlebar {
-  justify-content: center;
+#titlebar h1 {
+  margin-top: 20px;
+  color: #fff;
+  font-size: 1.5em;
+  font-weight: 300;
+  font-variant: small-caps;
+  text-transform: uppercase;
+  letter-spacing: .7em;
+  padding-left: .7em;
+  text-align: center;
 }
 
 #controller {
-  grid-area: 3 / 1;
   display: grid;
-  justify-content: center;
   grid-template: 100vmin / 100vmin;
+  justify-content: center;
+  align-content: center;
+}
+
+#game-buttons {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+
+  padding: 0px 5px;
+}
+
+#game-buttons button {
+  padding: 0px 5px;
+  width: calc(50% - 5px);
+  background-color: rgba(0, 0, 20, 0.2);
+
+  text-transform: lowercase;
+  font-variant: small-caps;
+  letter-spacing: .1em;
+
+  border-color: #bbb;
 }
 
 #dpad-canvas {
   display: block;
-  width: 100%;
+  width: calc(100% - 10px);
   height: 100%;
-}
 
-#game-buttons {
-  grid-area: 2 / 1;
-  border-bottom: $navbar-border;
-  padding: 0px 5px;
+  margin: 0 auto;
 }
 
 @media screen and (orientation: landscape) {
-  :host {
-    grid-template-rows: $titlebar 1fr;
-  }
-
-  #titlebar {
-    display: none;
-    position: absolute;
-  }
 
   #controller {
-    grid-area: 2 / 1;
-    grid-template: calc(100vmin - #{($titlebar) + 100px}) / calc(100vmin - #{($titlebar) + 100px});
-
+    grid-template: calc(100vmin - #{($titlebar) * 2}) / calc(100vmin - #{($titlebar) * 2});
   }
-
-  #game-buttons {
-    grid-area: 1 / 1;
-  }
-}
-
-#game-buttons .btn {
-  width: calc(50% - 2.5px);
-  height: 40px;
-  font-size: 0.8em;
 }

--- a/frontend/prebuild/src/app/controls/controls.component.scss
+++ b/frontend/prebuild/src/app/controls/controls.component.scss
@@ -10,12 +10,8 @@ body {
   display: grid;
   grid-template-rows: $titlebar $titlebar 1fr;
   grid-template-columns: 1fr;
-/*   display: flex;
-  flex-direction: column; */
 
   height: 100vh;
-
-  background-color: white;
 }
 
 .navbar {
@@ -48,11 +44,6 @@ body {
   display: block;
   width: 100%;
   height: 100%;
-
-  background-image: url('../../assets/images/dpad.png');
-  background-size: contain;
-  background-position: center;
-  background-repeat: no-repeat;
 }
 
 #game-buttons {

--- a/frontend/prebuild/src/app/controls/controls.component.ts
+++ b/frontend/prebuild/src/app/controls/controls.component.ts
@@ -72,34 +72,42 @@ export class ControlsComponent implements OnInit {
       evt.preventDefault();
     });
 
+    this.canvas.addEventListener('touchend', (evt:TouchEvent) => {
+      this.touchEnded(evt);
+    });
+
     this.canvas.addEventListener('mousedown', (evt: MouseEvent) => {
       this.mouseDown(evt);
+    });
+
+    this.canvas.addEventListener('mouseup', (evt: MouseEvent) => {
+      this.mouseUp(evt);
     });
 
     const canvasWidth = this.canvas.width;
     const canvasHeight = this.canvas.height;
 
     this.upTriangle = new Triangle(
-      new Point(0, 0),
-      new Point(canvasWidth, 0),
+      new Point(0 + 1, 0 + 1),
+      new Point(canvasWidth - 1, 0 + 1),
       new Point(canvasWidth / 2, canvasHeight / 2)
     );
 
     this.leftTriangle = new Triangle(
-      new Point(0, canvasHeight),
-      new Point(0, 0),
+      new Point(0 + 1, canvasHeight - 1),
+      new Point(0 + 1, 0 + 1),
       new Point(canvasWidth / 2, canvasHeight / 2)
     );
 
     this.downTriangle = new Triangle(
-      new Point(canvasWidth, canvasHeight),
-      new Point(0, canvasHeight),
+      new Point(canvasWidth - 1, canvasHeight - 1),
+      new Point(0 + 1, canvasHeight - 1),
       new Point(canvasWidth / 2, canvasHeight / 2)
     );
 
     this.rightTriangle = new Triangle(
-      new Point(canvasWidth, 0),
-      new Point(canvasWidth, canvasHeight),
+      new Point(canvasWidth - 1, 0 + 1),
+      new Point(canvasWidth - 1, canvasHeight - 1),
       new Point(canvasWidth / 2, canvasHeight / 2)
     );
 
@@ -110,7 +118,9 @@ export class ControlsComponent implements OnInit {
     const ctx = this.context;
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     ctx.strokeStyle = 'white';
-    ctx.fillStyle = 'white';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
+
+    ctx.lineWidth = 2;
 
 
     // Draw up button
@@ -125,6 +135,15 @@ export class ControlsComponent implements OnInit {
       ctx.fill();
     }
 
+    // Draw up arrow
+    const upArrow = this.upTriangle.scale(0.3).rotate(Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(upArrow.point1.x, upArrow.point1.y);
+    ctx.lineTo(upArrow.point2.x, upArrow.point2.y);
+    ctx.lineTo(upArrow.point3.x, upArrow.point3.y);
+    ctx.closePath();
+    ctx.stroke();
+
     // Draw left button
     ctx.beginPath();
     ctx.moveTo(this.leftTriangle.point1.x, this.leftTriangle.point1.y);
@@ -136,6 +155,15 @@ export class ControlsComponent implements OnInit {
     if (this.leftPressed) {
       ctx.fill();
     }
+
+    // Draw left arrow
+    const leftArrow = this.leftTriangle.scale(0.3).rotate(Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(leftArrow.point1.x, leftArrow.point1.y);
+    ctx.lineTo(leftArrow.point2.x, leftArrow.point2.y);
+    ctx.lineTo(leftArrow.point3.x, leftArrow.point3.y);
+    ctx.closePath();
+    ctx.stroke();
 
     // Draw down button
     ctx.beginPath();
@@ -149,6 +177,15 @@ export class ControlsComponent implements OnInit {
       ctx.fill();
     }
 
+    // Draw down arrow
+    const downArrow = this.downTriangle.scale(0.3).rotate(Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(downArrow.point1.x, downArrow.point1.y);
+    ctx.lineTo(downArrow.point2.x, downArrow.point2.y);
+    ctx.lineTo(downArrow.point3.x, downArrow.point3.y);
+    ctx.closePath();
+    ctx.stroke();
+
     // Draw right button
     ctx.beginPath();
     ctx.moveTo(this.rightTriangle.point1.x, this.rightTriangle.point1.y);
@@ -161,6 +198,15 @@ export class ControlsComponent implements OnInit {
       ctx.fill();
     }
 
+    // Draw right arrow
+    const rightArrow = this.rightTriangle.scale(0.3).rotate(Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(rightArrow.point1.x, rightArrow.point1.y);
+    ctx.lineTo(rightArrow.point2.x, rightArrow.point2.y);
+    ctx.lineTo(rightArrow.point3.x, rightArrow.point3.y);
+    ctx.closePath();
+    ctx.stroke();
+
     window.requestAnimationFrame(() => this.draw());
   }
 
@@ -171,9 +217,19 @@ export class ControlsComponent implements OnInit {
     }
   }
 
+  touchEnded(evt: TouchEvent) {
+    console.log(evt);
+    this.canvasReleased(evt.changedTouches[0].pageX, evt.changedTouches[0].pageY);
+  }
+
   mouseDown(evt: MouseEvent) {
     console.log(evt);
     this.canvasPressed(evt.pageX, evt.pageY);
+  }
+
+  mouseUp(evt: MouseEvent) {
+    console.log(evt);
+    this.canvasReleased(evt.pageX, evt.pageY);
   }
 
   canvasPressed(x: number, y: number) {
@@ -207,6 +263,29 @@ export class ControlsComponent implements OnInit {
       this.rightPressed = true;
       this.moveRight();
     } else {
+      this.rightPressed = false;
+    }
+  }
+
+  canvasReleased(x: number, y: number) {
+    const locationX = (x - this.canvas.offsetLeft) * this.canvas.width / this.canvas.offsetWidth;
+    const locationY = (y - this.canvas.offsetTop) * this.canvas.height / this.canvas.offsetHeight;
+
+    const location = new Point(locationX, locationY);
+
+    if (this.upTriangle.containsPoint(location)) {
+      this.upPressed = false;
+    }
+
+    if (this.leftTriangle.containsPoint(location)) {
+      this.leftPressed = false;
+    }
+
+    if (this.downTriangle.containsPoint(location)) {
+      this.downPressed = false;
+    }
+
+    if (this.rightTriangle.containsPoint(location)) {
       this.rightPressed = false;
     }
   }

--- a/frontend/prebuild/src/app/controls/controls.component.ts
+++ b/frontend/prebuild/src/app/controls/controls.component.ts
@@ -21,6 +21,11 @@ export class ControlsComponent implements OnInit {
   downTriangle: Triangle;
   rightTriangle: Triangle;
 
+  upPressed: boolean;
+  leftPressed: boolean;
+  downPressed: boolean;
+  rightPressed: boolean;
+
   constructor(private gameService: GameService) {
     gameService.messages.subscribe((msg) => {
       const json = msg as any;
@@ -97,6 +102,66 @@ export class ControlsComponent implements OnInit {
       new Point(canvasWidth, canvasHeight),
       new Point(canvasWidth / 2, canvasHeight / 2)
     );
+
+    window.requestAnimationFrame(() => this.draw());
+  }
+
+  draw() {
+    const ctx = this.context;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    ctx.strokeStyle = 'white';
+    ctx.fillStyle = 'white';
+
+
+    // Draw up button
+    ctx.beginPath();
+    ctx.moveTo(this.upTriangle.point1.x, this.upTriangle.point1.y);
+    ctx.lineTo(this.upTriangle.point2.x, this.upTriangle.point2.y);
+    ctx.lineTo(this.upTriangle.point3.x, this.upTriangle.point3.y);
+    ctx.closePath();
+    ctx.stroke();
+
+    if (this.upPressed) {
+      ctx.fill();
+    }
+
+    // Draw left button
+    ctx.beginPath();
+    ctx.moveTo(this.leftTriangle.point1.x, this.leftTriangle.point1.y);
+    ctx.lineTo(this.leftTriangle.point2.x, this.leftTriangle.point2.y);
+    ctx.lineTo(this.leftTriangle.point3.x, this.leftTriangle.point3.y);
+    ctx.closePath();
+    ctx.stroke();
+
+    if (this.leftPressed) {
+      ctx.fill();
+    }
+
+    // Draw down button
+    ctx.beginPath();
+    ctx.moveTo(this.downTriangle.point1.x, this.downTriangle.point1.y);
+    ctx.lineTo(this.downTriangle.point2.x, this.downTriangle.point2.y);
+    ctx.lineTo(this.downTriangle.point3.x, this.downTriangle.point3.y);
+    ctx.closePath();
+    ctx.stroke();
+
+    if (this.downPressed) {
+      ctx.fill();
+    }
+
+    // Draw right button
+    ctx.beginPath();
+    ctx.moveTo(this.rightTriangle.point1.x, this.rightTriangle.point1.y);
+    ctx.lineTo(this.rightTriangle.point2.x, this.rightTriangle.point2.y);
+    ctx.lineTo(this.rightTriangle.point3.x, this.rightTriangle.point3.y);
+    ctx.closePath();
+    ctx.stroke();
+
+    if (this.rightPressed) {
+      ctx.fill();
+    }
+
+    window.requestAnimationFrame(() => this.draw());
   }
 
   touchStarted(evt: TouchEvent) {
@@ -118,19 +183,31 @@ export class ControlsComponent implements OnInit {
     const location = new Point(locationX, locationY);
 
     if (this.upTriangle.containsPoint(location)) {
+      this.upPressed = true;
       this.moveUp();
+    } else {
+      this.upPressed = false;
     }
 
     if (this.leftTriangle.containsPoint(location)) {
+      this.leftPressed = true;
       this.moveLeft();
+    } else {
+      this.leftPressed = false;
     }
 
     if (this.downTriangle.containsPoint(location)) {
+      this.downPressed = true;
       this.moveDown();
+    } else {
+      this.downPressed = false;
     }
 
     if (this.rightTriangle.containsPoint(location)) {
+      this.rightPressed = true;
       this.moveRight();
+    } else {
+      this.rightPressed = false;
     }
   }
 

--- a/frontend/prebuild/src/app/controls/controls.component.ts
+++ b/frontend/prebuild/src/app/controls/controls.component.ts
@@ -9,6 +9,8 @@ import { Point } from '../geom/point';
   styleUrls: ['./controls.component.scss']
 })
 export class ControlsComponent implements OnInit {
+  windowHeight = window.innerHeight;
+
   roundId: string;
   serverHost: string;
   serverPort: string;
@@ -115,6 +117,7 @@ export class ControlsComponent implements OnInit {
   }
 
   draw() {
+    this.windowHeight = window.innerHeight;
     const ctx = this.context;
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     ctx.strokeStyle = 'white';

--- a/frontend/prebuild/src/app/geom/triangle.ts
+++ b/frontend/prebuild/src/app/geom/triangle.ts
@@ -13,7 +13,7 @@ export class Triangle {
 
   // Adapted from https://www.gamedev.net/forums/topic/295943-is-this-a-better-point-in-triangle-test-2d/?do=findComment&comment=2874043
   // Should tolerate either vertex winding direction
-  containsPoint(other: Point) {
+  containsPoint(other: Point): boolean {
     const b1 = this.sign(other, this.point1, this.point2) < 0.0;
     const b2 = this.sign(other, this.point2, this.point3) < 0.0;
     const b3 = this.sign(other, this.point3, this.point1) < 0.0;
@@ -21,13 +21,78 @@ export class Triangle {
     return (b1 == b2) && (b2 == b3);
   }
 
-  sign(p1: Point, p2: Point, p3: Point) {
+  sign(p1: Point, p2: Point, p3: Point): number {
     const term1 = p1.x - p3.x;
     const term2 = p2.y - p3.y;
     const term3 = p2.x - p3.x;
     const term4 = p1.y - p3.y;
 
     return term1 * term2 - term3 * term4;
+  }
+
+  scale(factor: number): Triangle {
+    const center = new Point((this.point1.x + this.point2.x + this.point3.x) / 3.0,
+                             (this.point1.y + this.point2.y + this.point3.y) / 3.0);
+
+    // New points centered on origin
+    const newPoint1 = new Point(this.point1.x - center.x, this.point1.y - center.y);
+    const newPoint2 = new Point(this.point2.x - center.x, this.point2.y - center.y);
+    const newPoint3 = new Point(this.point3.x - center.x, this.point3.y - center.y);
+
+    // Scale about the origin
+    newPoint1.x = newPoint1.x * factor;
+    newPoint1.y = newPoint1.y * factor;
+
+    newPoint2.x = newPoint2.x * factor;
+    newPoint2.y = newPoint2.y * factor;
+
+    newPoint3.x = newPoint3.x * factor;
+    newPoint3.y = newPoint3.y * factor;
+
+    // Move back to original center
+    newPoint1.x = newPoint1.x + center.x;
+    newPoint1.y = newPoint1.y + center.y;
+
+    newPoint2.x = newPoint2.x + center.x;
+    newPoint2.y = newPoint2.y + center.y;
+
+    newPoint3.x = newPoint3.x + center.x;
+    newPoint3.y = newPoint3.y + center.y;
+
+    return new Triangle(newPoint1, newPoint2, newPoint3);
+  }
+
+  // Angle in radians
+  rotate(angle: number) {
+    const center = new Point((this.point1.x + this.point2.x + this.point3.x) / 3.0,
+                             (this.point1.y + this.point2.y + this.point3.y) / 3.0);
+
+    // New points centered on origin
+    const newPoint1 = new Point(this.point1.x - center.x, this.point1.y - center.y);
+    const newPoint2 = new Point(this.point2.x - center.x, this.point2.y - center.y);
+    const newPoint3 = new Point(this.point3.x - center.x, this.point3.y - center.y);
+
+    // Rotate about origin
+    newPoint1.x = newPoint1.x * Math.cos(angle) - newPoint1.y * Math.sin(angle);
+    newPoint1.y = newPoint1.y * Math.cos(angle) - newPoint1.x * Math.sin(angle);
+
+    newPoint2.x = newPoint2.x * Math.cos(angle) - newPoint2.y * Math.sin(angle);
+    newPoint2.y = newPoint2.y * Math.cos(angle) - newPoint2.x * Math.sin(angle);
+
+    newPoint3.x = newPoint3.x * Math.cos(angle) - newPoint3.y * Math.sin(angle);
+    newPoint3.y = newPoint3.y * Math.cos(angle) - newPoint3.x * Math.sin(angle);
+
+    // Move back to location
+    newPoint1.x = newPoint1.x + center.x;
+    newPoint1.y = newPoint1.y + center.y;
+
+    newPoint2.x = newPoint2.x + center.x;
+    newPoint2.y = newPoint2.y + center.y;
+
+    newPoint3.x = newPoint3.x + center.x;
+    newPoint3.y = newPoint3.y + center.y;
+
+    return new Triangle(newPoint1, newPoint2, newPoint3);
   }
 
 }


### PR DESCRIPTION
The controls page is now themed like the rest of the site. The control pad now indicates it can be pressed anywhere within the square and reacts to presses. You can drag your finger over the buttons to press them, too.

Portrait:
<img width="487" alt="screen shot 2018-03-28 at 5 45 45 pm" src="https://user-images.githubusercontent.com/1577201/38060382-1566ed42-32b0-11e8-8f55-838ff764fa9c.png">

Landscape:
![under-construction-animated-gif-8](https://user-images.githubusercontent.com/1577201/38060416-40382a86-32b0-11e8-9e31-aa3a716668ee.gif)
