### PR TITLE
Landscape controls

### DIFF
--- a/frontend/prebuild/src/app/controls/controls.component.html
+++ b/frontend/prebuild/src/app/controls/controls.component.html
@@ -1,11 +1,14 @@
-<div id="titlebar" class="navbar">
-  <h1>Liberty Bikes</h1>
+<div id="controls-container"  [style.height.px]="windowHeight">
+  <div id="titlebar" class="navbar">
+    <h1>Liberty Bikes</h1>
+  </div>
+  <div id="game-buttons" class="navbar">
+    <button type="button" (click)="startGame()">Start Game</button>
+    <button type="button" (click)="requeue()">Requeue</button>
+  </div>
+  <div id="controller">
+    <canvas id="dpad-canvas" width="800" height="800"></canvas>
+  </div>
 </div>
-<div id="game-buttons" class="navbar">
-  <button type="button" (click)="startGame()">Start Game</button>
-  <button type="button" (click)="requeue()">Requeue</button>
-</div>
-<div id="controller" [style.height.px]="windowHeight">
-  <canvas id="dpad-canvas" width="800" height="800"></canvas>
-</div>
+
 

--- a/frontend/prebuild/src/app/controls/controls.component.scss
+++ b/frontend/prebuild/src/app/controls/controls.component.scss
@@ -13,6 +13,17 @@ body {
   height: 100%;
 }
 
+#controls-container {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+}
+
 .navbar {
   background-color: rgba(0, 0, 0, 0.2);
 
@@ -28,6 +39,8 @@ body {
   position: fixed;
   top: 0;
   width: 100%;
+
+  background: none;
 
   justify-content: center;
 }
@@ -57,6 +70,8 @@ body {
   width: 100%;
 
   padding: 0px 5px;
+
+  border-top: 1px solid white;
 }
 
 #game-buttons button {
@@ -79,25 +94,61 @@ body {
   margin: 0 auto;
 }
 
+@media screen and (max-height: 465px) {
+  #titlebar h1 {
+    font-size: 1em;
+  }
+}
+
 @media screen and (orientation: landscape) {
-  :host {
+  #controls-container {
     display: grid;
     grid-template-rows: 1fr 1fr;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: auto 1fr;
+
+    justify-content: center;
+    align-items: center;
+
+    padding: 0 20px;
   }
 
   #titlebar {
     position: relative;
     grid-area: 1 / 2;
+
+    background: none;
+    height: 100%;
+
+    font-size: 1.5em;
   }
 
   #game-buttons {
     position: relative;
     grid-area: 2 / 2;
+
+    height: 100%;
+
+    justify-content: space-around;
+    align-items: flex-start;
+
+    border-top: none;
+    background: none;
+  }
+
+  #game-buttons button {
+    width: 150px;
+    height: 100px;
+    letter-spacing: unset;
   }
 
   #controller {
     grid-area: 1 / 1 / span 2 / span 1;
     grid-template: calc(100vmin - #{($titlebar) * 2}) / calc(100vmin - #{($titlebar) * 2});
+  }
+
+  @media screen and (max-height: 320px), screen and (max-width: 569px) {
+    #game-buttons button {
+      height: 50px;
+    }
   }
 }

--- a/frontend/prebuild/src/app/controls/controls.component.scss
+++ b/frontend/prebuild/src/app/controls/controls.component.scss
@@ -80,8 +80,24 @@ body {
 }
 
 @media screen and (orientation: landscape) {
+  :host {
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  #titlebar {
+    position: relative;
+    grid-area: 1 / 2;
+  }
+
+  #game-buttons {
+    position: relative;
+    grid-area: 2 / 2;
+  }
 
   #controller {
+    grid-area: 1 / 1 / span 2 / span 1;
     grid-template: calc(100vmin - #{($titlebar) * 2}) / calc(100vmin - #{($titlebar) * 2});
   }
 }

--- a/frontend/prebuild/src/app/controls/controls.component.ts
+++ b/frontend/prebuild/src/app/controls/controls.component.ts
@@ -30,7 +30,12 @@ export class ControlsComponent implements OnInit, OnDestroy {
 
   private preventScrolling = (evt: TouchEvent) => {
     evt.preventDefault();
-  };
+  }
+
+  private pageWasResized = (evt: DeviceOrientationEvent) => {
+    this.windowHeight = window.innerHeight;
+    window.scrollTo(0, 0);
+  }
 
   constructor(private gameService: GameService) {
     gameService.messages.subscribe((msg) => {
@@ -65,6 +70,11 @@ export class ControlsComponent implements OnInit, OnDestroy {
         this.moveRight();
       }
     };
+
+    // Make sure the view is at the top of the page so touch event coordinates line up
+    window.scrollTo(0, 0);
+    window.addEventListener('orientationchange', this.pageWasResized);
+    window.addEventListener('resize', this.pageWasResized);
   }
 
   initCanvas() {
@@ -132,7 +142,9 @@ export class ControlsComponent implements OnInit, OnDestroy {
   }
 
   draw() {
-    this.windowHeight = window.innerHeight;
+    if (window.scrollY != 0) {
+      window.scrollTo(0, 0);
+    }
     const ctx = this.context;
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     ctx.strokeStyle = 'white';
@@ -342,5 +354,7 @@ export class ControlsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     window.removeEventListener('touchmove', this.preventScrolling);
+    window.removeEventListener('orientationchange', this.pageWasResized);
+    window.removeEventListener('resize', this.pageWasResized);
   }
 }

--- a/frontend/prebuild/src/app/controls/controls.component.ts
+++ b/frontend/prebuild/src/app/controls/controls.component.ts
@@ -236,8 +236,6 @@ export class ControlsComponent implements OnInit, OnDestroy {
     ctx.lineTo(rightArrow.point3.x, rightArrow.point3.y);
     ctx.closePath();
     ctx.stroke();
-
-    window.requestAnimationFrame(() => this.draw());
   }
 
   touchStarted(evt: TouchEvent) {
@@ -302,6 +300,8 @@ export class ControlsComponent implements OnInit, OnDestroy {
     } else {
       this.rightPressed = false;
     }
+
+    window.requestAnimationFrame(() => this.draw());
   }
 
   canvasReleased(x: number, y: number) {
@@ -325,6 +325,8 @@ export class ControlsComponent implements OnInit, OnDestroy {
     if (this.rightTriangle.containsPoint(location)) {
       this.rightPressed = false;
     }
+
+    window.requestAnimationFrame(() => this.draw());
   }
 
   // Game actions


### PR DESCRIPTION
Finishing the work in PR #51, this PR gets the layout much better when phones are in landscape mode. I moved the d-pad over to the left side, like a real controller, so it's much easier to reach. Hopefully there shouldn't be any instances of elements scrolling off screen growing too large.

Also, a few small portrait tweaks.

Nexus 5:
![screenshot_1522340186](https://user-images.githubusercontent.com/1577201/38101208-417d7b5e-3345-11e8-8a2d-81418434d287.png)

iPhone:
![img_0001](https://user-images.githubusercontent.com/1577201/38101185-32ded3fe-3345-11e8-8476-d6579b10512c.PNG)

iPhone Minus:
![img_0013](https://user-images.githubusercontent.com/1577201/38101196-39c76d20-3345-11e8-82b7-6a4ad6d06c96.PNG)

iPhone Plus:
![img_1862](https://user-images.githubusercontent.com/1577201/38101148-1f188662-3345-11e8-8f8a-3a956c325e8e.PNG)

The controller can handle appearing/disappearing UI elements now:
![img_1864](https://user-images.githubusercontent.com/1577201/38101149-1f2d9d04-3345-11e8-8bae-f9ab290d226f.PNG)

Portrait tweaks.

![img_1865](https://user-images.githubusercontent.com/1577201/38101150-1f46245a-3345-11e8-96b7-9d547d4ad09a.PNG)

![screenshot_1522340206](https://user-images.githubusercontent.com/1577201/38101210-4190dafa-3345-11e8-8016-c8ce9016f5c4.png)
