### PR TITLE
Firefox was broken with margin-top, so let's try padding-top instead

### DIFF
--- a/frontend/prebuild/src/app/game/leaderboard/leaderboard.component.scss
+++ b/frontend/prebuild/src/app/game/leaderboard/leaderboard.component.scss
@@ -1,13 +1,12 @@
 :host {
   display: grid;
-  grid-template-rows: repeat(2, 1fr);
+  grid-template-rows: 100%;
   grid-template-columns: 50px 1fr;
   min-height: 100%;
-  align-content: center;
+  padding-top: 15px;
 }
 
 #title {
-  grid-area: 1 / 1 / span 2 / 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -27,8 +26,3 @@
   padding: 0;
 }
 
-.leaderboard-container {
-  margin-left: 15px;
-  margin-top: 15px;
-  margin-right: 15px;
-}


### PR DESCRIPTION
This doesn't fix everything but it does resolve the weirdest part where the page just got massively tall in Firefox if you resize the window.

Three different browsers show the table in three different ways, which I guess is what happens when 1990s web elements (`<table>`) and 2010s elements (`display: grid`) collide.