### PR TITLE
Rework player drawing

### DIFF
--- a/frontend/prebuild/src/app/entity/player.tooltip.ts
+++ b/frontend/prebuild/src/app/entity/player.tooltip.ts
@@ -4,7 +4,7 @@ import { Constants } from '../game/constants';
 import { Tooltip } from './tooltip';
 
 export class PlayerTooltip {
-  static readonly tooltipDistance = Constants.BOX_SIZE * 3;
+  static readonly tooltipDistance = Constants.BOX_SIZE * 5;
 
   public tooltipShape: Container;
   public lifetime: number = 30;
@@ -26,6 +26,9 @@ export class PlayerTooltip {
       this.player.color,
       230
     ).object;
+
+    this.tooltipShape.regX = this.tooltipShape.getBounds().width / 2;
+    this.tooltipShape.regY = this.tooltipShape.getBounds().height / 2;
   }
 
   public update(direction?: string) {
@@ -33,17 +36,14 @@ export class PlayerTooltip {
       // Nothing to update
       return;
     }
-    const tooltipBounds = this.tooltipShape.getBounds();
-    const playerBounds = this.player.image.getBounds();
-    let verticalMargin = PlayerTooltip.tooltipDistance * 2;
+    const tooltipBounds = this.tooltipShape.getTransformedBounds();
+    const playerBounds = this.player.image.getTransformedBounds();
+    let verticalMargin = PlayerTooltip.tooltipDistance;
 
     // positioning
-    // If label positioning becomes misaligned again, rewrite this to use the player size etc
-    // rather than magic constants.
-
-    if (this.player.y > Constants.BOARD_SIZE - (tooltipBounds.height + verticalMargin + playerBounds.height)) {
+    if (this.player.y > Constants.BOARD_SIZE - (this.player.image.getTransformedBounds().height / 2 + verticalMargin + tooltipBounds.height)) {
       this.showAbove = true;
-    } else if (this.player.y <= (tooltipBounds.height + verticalMargin)) {
+    } else if (this.player.y <= (this.player.image.getTransformedBounds().height / 2 + verticalMargin + tooltipBounds.height)) {
       this.showAbove = false;
     } else if (this.player.y < this.lastY) {
       this.showAbove = false;
@@ -60,30 +60,21 @@ export class PlayerTooltip {
     this.lastX = this.player.x;
     this.lastY = this.player.y;
 
-    if (this.playerVertical) {
-      this.tooltipShape.x = (this.player.x - tooltipBounds.width / 2) + playerBounds.width / 2;
-      if (this.showAbove) {
-        this.tooltipShape.y = (this.player.y - tooltipBounds.height) - verticalMargin;
-      } else {
-        this.tooltipShape.y = (this.player.y + playerBounds.height) + verticalMargin;
-      }
+    // The player sprite and tooltip are both registered at their center, rather than top left
+    this.tooltipShape.x = this.player.image.x;
+    if (this.showAbove) {
+      this.tooltipShape.y = (this.player.image.y - (tooltipBounds.height / 2 + playerBounds.height / 2 + verticalMargin));
     } else {
-      // The image rotates, but the bounds don't, so swap width and height for the player bounds
-      this.tooltipShape.x = (this.player.x - tooltipBounds.width / 2);
-      if (this.showAbove) {
-        this.tooltipShape.y = (this.player.y - tooltipBounds.height) - verticalMargin;
-      } else {
-        this.tooltipShape.y = (this.player.y + playerBounds.height) + verticalMargin;
-      }
+      this.tooltipShape.y = (this.player.image.y + (tooltipBounds.height / 2 + playerBounds.height / 2 + verticalMargin));
     }
 
     // prevent tooltip from going off screen
-    if (this.tooltipShape.x < 0) {
-      this.tooltipShape.x = 0;
+    if (this.player.x < tooltipBounds.width / 2) {
+      this.tooltipShape.x = (tooltipBounds.width / 2) - this.player.x;
     }
 
-    if (this.tooltipShape.x + tooltipBounds.width > Constants.BOARD_SIZE) {
-      this.tooltipShape.x = Constants.BOARD_SIZE - tooltipBounds.width;
+    if (this.player.x + (tooltipBounds.width / 2) > Constants.BOARD_SIZE) {
+      this.tooltipShape.x = -(this.player.x + tooltipBounds.width / 2) + Constants.BOARD_SIZE;
     }
 
     // start fading out after 15 ticks

--- a/frontend/prebuild/src/app/entity/player.ts
+++ b/frontend/prebuild/src/app/entity/player.ts
@@ -16,38 +16,39 @@ export class Player {
   direction: string;
 
   public update(x: number, y: number, direction: string) {
-	//console.log(`[Player-${this.name}]  x=${x}  y=${y}  direction=${direction}`);
-	let playerMoved: boolean = (this.x !== x) || (this.y !== y) || (this.direction !== direction);
+    //console.log(`[Player-${this.name}]  x=${x}  y=${y}  direction=${direction}`);
+    let playerMoved: boolean = this.x !== x || this.y !== y || this.direction !== direction;
     this.x = x;
     this.y = y;
     this.direction = direction;
-	if (!this.tooltip)
-	  this.tooltip = new PlayerTooltip(this);
-	if (!this.image) {
+
+    if (!this.tooltip) {
+      this.tooltip = new PlayerTooltip(this);
+    }
+
+    if (!this.image) {
       this.image = Assets.PLAYER_BITMAP.clone();
+      this.image.regX = this.image.getBounds().width / 2;
+      this.image.regY = this.image.getBounds().height / 2;
       this.image.scaleX = 2.0;
       this.image.scaleY = 2.0;
-	}
+    }
 
-	if (direction === 'UP') {
+    if (direction === 'UP') {
       this.image.rotation = 0;
-  	  this.image.x = x - 10;
-  	  this.image.y = y - 10;
-	} else if (direction === 'RIGHT') {
+    } else if (direction === 'RIGHT') {
       this.image.rotation = 90;
-  	  this.image.x = x + 40;
-  	  this.image.y = y - 10;
-	} else if (direction === 'DOWN') {
+    } else if (direction === 'DOWN') {
       this.image.rotation = 180;
-  	  this.image.x = x + 40;
-  	  this.image.y = y + 40;
-	} else {
+    } else {
       this.image.rotation = 270;
-  	  this.image.x = x - 10;
-  	  this.image.y = y + 40;
-	}
-	this.tooltip.update(direction);
-	return playerMoved;
+    }
+
+    this.image.x = x;
+    this.image.y = y;
+    this.tooltip.update(direction);
+
+    return playerMoved;
   }
 
   public visible(isVisible: boolean) {
@@ -61,8 +62,8 @@ export class Player {
       this.explosionImage = Assets.PLAYER_DEAD_BITMAP.clone();
       this.explosionImage.scaleX = 1.2;
       this.explosionImage.scaleY = 1.2;
-      this.explosionImage.x = this.x - 16;
-      this.explosionImage.y = this.y - 16;
+      this.explosionImage.x = this.x - this.explosionImage.getBounds().width / 2;
+      this.explosionImage.y = this.y - this.explosionImage.getBounds().height / 2;
       if (!Player.audioLoaded) {
         Player.audioLoaded = true;
         Assets.BAM.load();
@@ -73,17 +74,26 @@ export class Player {
   }
 
   public addTo(stage: Stage) {
-	  if (this.tooltip)
-	    stage.addChild(this.tooltip.tooltipShape);
-      stage.addChild(this.image);
-	  if (this.explosionImage)
-        stage.addChild(this.explosionImage);
+    if (this.tooltip) {
+      stage.addChild(this.tooltip.tooltipShape);
+    }
+
+    stage.addChild(this.image);
+
+    if (this.explosionImage) {
+      stage.addChild(this.explosionImage);
+    }
   }
+
   public removeFrom(stage: Stage) {
-	  if (this.tooltip)
-        stage.removeChild(this.tooltip.tooltipShape);
-	  if (this.explosionImage)
-        stage.removeChild(this.explosionImage);
-      stage.removeChild(this.image);
+    if (this.tooltip) {
+      stage.removeChild(this.tooltip.tooltipShape);
+    }
+
+    stage.removeChild(this.image);
+
+    if (this.explosionImage) {
+      stage.removeChild(this.explosionImage);
+    }
   }
 }

--- a/frontend/prebuild/src/app/entity/player.ts
+++ b/frontend/prebuild/src/app/entity/player.ts
@@ -1,9 +1,16 @@
-import { Shape, Bitmap, Stage } from 'createjs-module';
+import { Shape, Bitmap, Stage, Container } from 'createjs-module';
 import { PlayerTooltip } from './player.tooltip';
 import { Assets } from '../game/assets';
 
 export class Player {
+  displayObject: Container;
+
+  get object() {
+    return this.displayObject;
+  }
+
   static audioLoaded: boolean = false;
+  childrenLoaded: boolean = false;
 
   public name: string;
   public status: string;
@@ -13,6 +20,7 @@ export class Player {
   public image: Bitmap;
   public explosionImage: Bitmap;
   public tooltip: PlayerTooltip;
+
   direction: string;
 
   public update(x: number, y: number, direction: string) {
@@ -22,16 +30,26 @@ export class Player {
     this.y = y;
     this.direction = direction;
 
-    if (!this.tooltip) {
-      this.tooltip = new PlayerTooltip(this);
-    }
+    if (!this.childrenLoaded) {
+      this.displayObject = new Container();
 
-    if (!this.image) {
+      this.tooltip = new PlayerTooltip(this);
+      this.displayObject.addChild(this.tooltip.tooltipShape);
+
       this.image = Assets.PLAYER_BITMAP.clone();
       this.image.regX = this.image.getBounds().width / 2;
       this.image.regY = this.image.getBounds().height / 2;
       this.image.scaleX = 2.0;
       this.image.scaleY = 2.0;
+      this.displayObject.addChild(this.image);
+
+      this.explosionImage = Assets.PLAYER_DEAD_BITMAP.clone();
+      this.explosionImage.regX = this.explosionImage.getBounds().width / 2;
+      this.explosionImage.regY = this.explosionImage.getBounds().height / 2;
+      this.explosionImage.scaleX = 1.2;
+      this.explosionImage.scaleY = 1.2;
+
+      this.childrenLoaded = true;
     }
 
     if (direction === 'UP') {
@@ -44,26 +62,27 @@ export class Player {
       this.image.rotation = 270;
     }
 
-    this.image.x = x;
-    this.image.y = y;
+    this.displayObject.x = x;
+    this.displayObject.y = y;
     this.tooltip.update(direction);
 
     return playerMoved;
   }
 
   public visible(isVisible: boolean) {
-    this.image.visible = isVisible;
-    this.explosionImage.visible = isVisible;
-    this.tooltip.visible(isVisible);
+    if (this.childrenLoaded) {
+      this.image.visible = isVisible;
+      this.explosionImage.visible = isVisible;
+      this.tooltip.visible(isVisible);
+    }
+
   }
 
   public setStatus(status: string) {
-    if (status === 'Dead' && this.status !== 'Dead' && !this.explosionImage) {
-      this.explosionImage = Assets.PLAYER_DEAD_BITMAP.clone();
-      this.explosionImage.scaleX = 1.2;
-      this.explosionImage.scaleY = 1.2;
-      this.explosionImage.x = this.x - this.explosionImage.getBounds().width / 2;
-      this.explosionImage.y = this.y - this.explosionImage.getBounds().height / 2;
+    if (this.childrenLoaded && status === 'Dead' && this.status !== 'Dead') {
+      this.explosionImage.x = this.image.x;
+      this.explosionImage.y = this.image.y;
+      this.displayObject.addChild(this.explosionImage);
       if (!Player.audioLoaded) {
         Player.audioLoaded = true;
         Assets.BAM.load();
@@ -71,29 +90,5 @@ export class Player {
       Assets.BAM.play();
     }
     this.status = status;
-  }
-
-  public addTo(stage: Stage) {
-    if (this.tooltip) {
-      stage.addChild(this.tooltip.tooltipShape);
-    }
-
-    stage.addChild(this.image);
-
-    if (this.explosionImage) {
-      stage.addChild(this.explosionImage);
-    }
-  }
-
-  public removeFrom(stage: Stage) {
-    if (this.tooltip) {
-      stage.removeChild(this.tooltip.tooltipShape);
-    }
-
-    stage.removeChild(this.image);
-
-    if (this.explosionImage) {
-      stage.removeChild(this.explosionImage);
-    }
   }
 }

--- a/frontend/prebuild/src/app/entity/player.ts
+++ b/frontend/prebuild/src/app/entity/player.ts
@@ -1,4 +1,4 @@
-import { Shape, Bitmap, Stage, Container } from 'createjs-module';
+import { Bitmap, Container } from 'createjs-module';
 import { PlayerTooltip } from './player.tooltip';
 import { Assets } from '../game/assets';
 

--- a/frontend/prebuild/src/app/game/game.component.ts
+++ b/frontend/prebuild/src/app/game/game.component.ts
@@ -127,10 +127,10 @@ export class GameComponent implements OnInit, OnDestroy {
 
             newPlayer.update(playerInfo.x * Constants.BOX_SIZE + (playerInfo.width / 2) * Constants.BOX_SIZE, playerInfo.y * Constants.BOX_SIZE + (playerInfo.width / 2) * Constants.BOX_SIZE, playerInfo.direction);
 
-            newPlayer.addTo(this.stage);
+            this.stage.addChild(newPlayer.object);
           }
           oldPlayers.forEach((playerThatLeft: Player, id: string) => {
-            playerThatLeft.removeFrom(this.stage);
+            this.stage.removeChild(playerThatLeft.object);
           });
         }
         if (json.players) {

--- a/frontend/prebuild/src/app/game/game.component.ts
+++ b/frontend/prebuild/src/app/game/game.component.ts
@@ -140,15 +140,15 @@ export class GameComponent implements OnInit, OnDestroy {
         	    const playerEntity = this.players.get(player.id);
             if (player.status === 'Alive') {
             	  noneAlive = false;
-              if (playerEntity.update(player.x * Constants.BOX_SIZE, player.y * Constants.BOX_SIZE, player.direction))
+              if (playerEntity.update(player.x * Constants.BOX_SIZE + (player.width / 2) * Constants.BOX_SIZE, player.y * Constants.BOX_SIZE + (player.height / 2) * Constants.BOX_SIZE, player.direction))
             	    playersMoved = true;
 
               // Stamp down player on trails canvas so it can be erased properly when obstacles roll over it
               this.trailsContext.shadowBlur = 20;
               this.trailsContext.shadowColor = player.color;
               this.trailsContext.fillStyle = player.color;
-              this.trailsContext.fillRect(Constants.BOX_SIZE * player.x + player.width / 2 * Constants.BOX_SIZE - Constants.BOX_SIZE / 2,
-                Constants.BOX_SIZE * player.y + player.height / 2 * Constants.BOX_SIZE - Constants.BOX_SIZE / 2,
+              this.trailsContext.fillRect(Constants.BOX_SIZE * player.x + (player.width / 2) * Constants.BOX_SIZE - Constants.BOX_SIZE / 2,
+                Constants.BOX_SIZE * player.y + (player.height / 2) * Constants.BOX_SIZE - Constants.BOX_SIZE / 2,
                 Constants.BOX_SIZE, Constants.BOX_SIZE);
             } else if (!player.alive) {
             	  // Ensure tooltip is hidden in case player dies before it fades out

--- a/frontend/prebuild/src/app/game/game.component.ts
+++ b/frontend/prebuild/src/app/game/game.component.ts
@@ -125,7 +125,7 @@ export class GameComponent implements OnInit, OnDestroy {
             }
             this.players.set(playerInfo.id, newPlayer);
 
-            newPlayer.update(playerInfo.x * Constants.BOX_SIZE, playerInfo.y * Constants.BOX_SIZE, playerInfo.direction);
+            newPlayer.update(playerInfo.x * Constants.BOX_SIZE + (playerInfo.width / 2) * Constants.BOX_SIZE, playerInfo.y * Constants.BOX_SIZE + (playerInfo.width / 2) * Constants.BOX_SIZE, playerInfo.direction);
 
             newPlayer.addTo(this.stage);
           }


### PR DESCRIPTION
This moves some of the player drawing logic around. Now it uses a container to keep the various entities involved in drawing a player all in one display object, rather than trying to keep each individual part updated.