### PR TITLE
Single party deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Builds all microservice applications and deploys them to locally running liberty
 ./gradlew start frontend:open
 ```
 
+For a local setting, use single-party mode:
+```
+./gradlew start frontend:open -DsingleParty=true
+```
+
 Any code changes that are made in an eclipse environment with auto-build enabled will automatically publish content to the loose application, meaning no server restarts should be required between code changes.
 
 To stop all liberty servers, issue the command:

--- a/frontend/prebuild/src/app/login/login.component.html
+++ b/frontend/prebuild/src/app/login/login.component.html
@@ -60,11 +60,11 @@
             </div>
           </div>
           <div class="form-group">
-            <div *ngIf="isFullDevice" class="form-item">
+            <div *ngIf="isQuickPlayAllowed" class="form-item">
               <button type="button" (click)="quickJoin()">Play Now</button>
             </div>
 
-            <h2 *ngIf="isFullDevice" class="section-header" style="margin-bottom: 0">or</h2>
+            <h2 *ngIf="isQuickPlayAllowed" class="section-header" style="margin-bottom: 0">or</h2>
             <div class="form-item">
               <label>Party Code</label>
               <input type="text" id="roundid" name="roundid" [(ngModel)]="party" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">

--- a/frontend/prebuild/src/app/login/login.component.ts
+++ b/frontend/prebuild/src/app/login/login.component.ts
@@ -23,6 +23,7 @@ export class LoginComponent implements OnInit, OnDestroy {
   queuePosition: number;
   player = new Player();
   isFullDevice: boolean = !/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+  isQuickPlayAllowed: boolean = this.isFullDevice;
 
   constructor(
     private router: Router,
@@ -66,6 +67,8 @@ export class LoginComponent implements OnInit, OnDestroy {
       this.setQueueOnMessage();
       this.showQueue(queuePosition);
     }
+    
+    this.checkForQuickPlay();
   }
 
   ngOnDestroy() {
@@ -82,6 +85,27 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   loginTwitter() {
       window.location.href = `${environment.API_URL_AUTH}/auth-service/TwitterAuth`;
+  }
+  
+  async checkForQuickPlay() {
+    if (this.isQuickPlayAllowed) {
+    	  console.log('Quick play is supported -- skipping party service check');
+    	  return;
+    }
+    
+    let data: any = await this.http.get(`${environment.API_URL_PARTY}/describe`).toPromise();
+    if (data == null) {
+    	  console.log('WARNING: Unable to contact party service to determine if quick play is allowed');
+    }
+    
+    if (data.isSingleParty === true) {
+    	  console.log('Quick play is supported');
+    	  this.ngZone.run(() => {
+        this.isQuickPlayAllowed = true;
+    	  });
+    } else {
+      console.log('Quick play is NOT supported');
+    }
   }
 
   async quickJoin() {

--- a/game-service/build.gradle
+++ b/game-service/build.gradle
@@ -13,7 +13,8 @@ liberty {
 		dropins = [war]
 		bootstrapProperties = ['httpPort': httpPort, 'httpsPort': httpsPort]
 		configDirectory = file('src/main/liberty/config')
-		jvmOptions = ['-Dorg.libertybikes.restclient.PlayerService/mp-rest/url=http://localhost:8081/']
+		jvmOptions = ['-Dorg.libertybikes.restclient.PlayerService/mp-rest/url=http://localhost:8081/',
+		              '-DsingleParty=' + System.getProperty('singleParty', 'false')]
 	}
 }
 


### PR DESCRIPTION
When running the game on a local network (e.g. a conference) there is usually only one party being used, but users still need to identify and type in what the party code is.

To simplify the conference scenario, allow a new deployment option `-DsingleParty=true` to be specified which allows a singleton party to be used so that mobile users can use the "quick play" option.