### PR TITLE
Add size=3 glowing border to game board

### DIFF
--- a/frontend/prebuild/src/app/game/game.component.ts
+++ b/frontend/prebuild/src/app/game/game.component.ts
@@ -139,6 +139,13 @@ export class GameComponent implements OnInit, OnDestroy {
     this.obstaclesShape.y = 0;
 
     this.stage.addChild(this.obstaclesShape);
+    
+    // Create a red border around the game board
+    let BORDER_WIDTH = 3;
+    this.addBorder(0, 0, Constants.BOARD_SIZE, BORDER_WIDTH); // top
+    this.addBorder(0, Constants.BOARD_SIZE-BORDER_WIDTH, Constants.BOARD_SIZE, BORDER_WIDTH); // bottom
+    this.addBorder(0, 0, BORDER_WIDTH, Constants.BOARD_SIZE); // left
+    this.addBorder(Constants.BOARD_SIZE-BORDER_WIDTH, 0, BORDER_WIDTH, Constants.BOARD_SIZE); // right
 
     this.stage.update();
 
@@ -482,6 +489,13 @@ export class GameComponent implements OnInit, OnDestroy {
         this.router.navigate(['/login']);
       });
     }
+  }
+  
+  addBorder(x, y, w, h) {
+	let shape: Shape = new Shape();
+  	shape.shadow = new Shadow(Obstacle.COLOR, 0, 0, 20);
+  	shape.graphics.beginFill(Obstacle.COLOR).rect(x,y,w,h);
+	this.stage.addChild(shape);
   }
 
 }

--- a/frontend/prebuild/src/app/game/game.service.ts
+++ b/frontend/prebuild/src/app/game/game.service.ts
@@ -19,7 +19,7 @@ export class GameService {
     socketService.url = `${environment.API_URL_GAME_WS}/${this.roundId}`;
     this.messages = <Subject<Object>>socketService.socket
     .pipe(map((response: MessageEvent): any => {
-      console.log(`Game service handling message: ${response.data}`);
+      //console.log(`Game service handling message: ${response.data}`);
       return JSON.parse(response.data);
     }));
   }


### PR DESCRIPTION
Fixes #140 

Creates a small red border with no collision value around the game board to help indicate that a player cannot wrap around the game board (like pac-man)
![screen shot 2018-10-15 at 2 29 36 pm](https://user-images.githubusercontent.com/5427967/46973974-609f9180-d088-11e8-9894-b9ba62d49a2c.png)
