### PR TITLE
Convert buttons to be contextual

### DIFF
--- a/frontend/prebuild/src/app/game/game.component.html
+++ b/frontend/prebuild/src/app/game/game.component.html
@@ -24,6 +24,5 @@
 </div>
 
 <div id="footer" class="navbar">
-  <button type="button" (click)="startGame()">Start Game</button>
-  <button *ngIf="!(this.isSpectator && this.isSingleParty)" type="button" (click)="requeue()">Requeue</button>
+  <button type="button" (click)="gameButtonPressed()" [disabled]="gameButtonDisabled">{{gameButtonText}}</button>
 </div>


### PR DESCRIPTION
Reduce the two buttons down to one. Start game is shown unless the player is dead or the game is over. Start game is disabled while games are in progress. Requeue is shown when the player is dead or the game is over. It is disabled for spectators, who get a countdown on the button before auto requeue.

![image](https://user-images.githubusercontent.com/1577201/47183648-2e8f6900-d2ee-11e8-8a8e-33f7dca30887.png)

![screen shot 2018-10-18 at 3 55 33 pm](https://user-images.githubusercontent.com/1577201/47183691-48c94700-d2ee-11e8-88f7-791f52045600.png)

<img width="1516" alt="screen shot 2018-10-18 at 4 14 32 pm" src="https://user-images.githubusercontent.com/1577201/47185063-0d307c00-d2f2-11e8-87f5-997ecf22c3d4.png">

