### PR TITLE
Party code hiding

### DIFF
--- a/frontend/prebuild/src/app/game/game.component.html
+++ b/frontend/prebuild/src/app/game/game.component.html
@@ -1,7 +1,10 @@
 <div id="titlebar" class="navbar">
-  <h1>Liberty Bikes</h1>
-  <div id="game-code-display" *ngIf="showPartyId">
+  <h1 id="logo">Liberty<br />Bikes</h1>
+  <div id="game-code-display" *ngIf="!isSingleParty && showPartyId">
     <h2>code: <span id="game-code">{{partyId}}</span></h2>
+  </div>
+  <div id="game-url-display" *ngIf="isSingleParty && isSpectator">
+    {{window.location.protocol}}//{{window.location.host}}
   </div>
 </div>
 

--- a/frontend/prebuild/src/app/game/game.component.scss
+++ b/frontend/prebuild/src/app/game/game.component.scss
@@ -56,7 +56,7 @@ body {
   border-bottom: $navbar-border;
 }
 
-#titlebar h1 {
+#logo {
   color: #fff;
   font-size: 1.5em;
   font-weight: 300;
@@ -64,6 +64,9 @@ body {
   text-transform: uppercase;
   margin-left: 10px;
   letter-spacing: .7em;
+
+  flex: 0;
+  text-align: center;
 }
 
 #titlebar h2 {
@@ -73,11 +76,21 @@ body {
 
 #game-code-display {
   font-weight: bolder;
+  flex: 1;
+  text-align: end;
 }
 
 #game-code {
   font-size: 1.5em;
   font-family: "Avenir-Black", "Arial Black", "Roboto Black", sans-serif;
+}
+
+#game-url-display {
+  flex: 1;
+  text-align: end;
+  font-size: 1.5em;
+  line-height: 1em;
+  color: white;
 }
 
 .navbar .btn {

--- a/frontend/prebuild/src/app/game/game.component.ts
+++ b/frontend/prebuild/src/app/game/game.component.ts
@@ -40,6 +40,9 @@ export class GameComponent implements OnInit, OnDestroy {
 
   currentState: GameState;
 
+  // Expose window object to template
+  window = window;
+
   get state(): GameState {
     return this.currentState;
   }

--- a/frontend/prebuild/src/app/login/login.component.html
+++ b/frontend/prebuild/src/app/login/login.component.html
@@ -103,7 +103,7 @@
         <div queuePane>
           <div class="form-group">
             <div class="form-item">
-              <h2>The current round for party {{party}} is full! Hang out a bit and you will automatically join the next round.</h2>
+              <h2>The current round <span *ngIf="!this.isSingleParty">for party {{party}} </span>is full! Hang out a bit and you will automatically join the next round.</h2>
               <hr/>
               <!-- TODO: Display the queue number more prominently -->
               <h2>You are number {{queuePosition}} in queue</h2>


### PR DESCRIPTION
Hide the party code from the queue message in single party mode, and replace the game code with the url as the browser sees it. Only shows the protocol and host, not any context root that may be in the URL.

<img width="1647" alt="screen shot 2018-10-19 at 3 04 16 pm" src="https://user-images.githubusercontent.com/1577201/47241749-6a8c0200-d3b2-11e8-9d1d-6526b6592085.png">

<img width="1647" alt="screen shot 2018-10-19 at 3 04 31 pm" src="https://user-images.githubusercontent.com/1577201/47241755-724ba680-d3b2-11e8-9a2e-effd31758888.png">
