### PR TITLE
Fix dockerfiles to run with nonroot OL container

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,6 +1,6 @@
-FROM openliberty/open-liberty:microProfile1
-ADD build/libs/auth-service.war /config/dropins
-COPY src/main/liberty/config /config/
+FROM open-liberty:microProfile1
+ADD --chown=1001:0 build/libs/auth-service.war /config/dropins
+COPY --chown=1001:0 src/main/liberty/config /config/
 RUN printf 'frontend_url=http://lb-frontend:12000/login\n\
 auth_url=https://lb-auth:8082/auth-service' > /config/server.env
 RUN printf 'httpPort=8082\n\

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.4.+'
+        classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.6.3'
     }
 }
 
 plugins {
-    id 'com.avast.gradle.docker-compose' version "0.8.0"
+    id 'com.avast.gradle.docker-compose' version "0.9.1"
 }
 
 task clean(type: Delete) {
@@ -57,7 +57,7 @@ subprojects {
             mavenCentral()
         }
         dependencies {
-            classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.4.+'
+            classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.6.3'
         }
     }
 
@@ -71,7 +71,7 @@ subprojects {
         testCompile group: 'junit', name: 'junit', version: '4.+'
         testCompile group: 'org.eclipse', name: 'yasson', version: '1.0.1'
         testCompile group: 'org.glassfish', name: 'javax.json', version: '1.1.+'
-        libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '[18.0.0.3,)'
+        libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '[19.0.0.3,)'
     }
     
     eclipse {

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
-FROM openliberty/open-liberty:microProfile1
-ADD build/libs/frontend.war /config/apps
-COPY src/main/liberty/config /config/
+FROM open-liberty:microProfile1
+ADD --chown=1001:0 build/libs/frontend.war /config/apps
+COPY --chown=1001:0 src/main/liberty/config /config/
 RUN printf 'httpPort=12000\n\
 httpsPort=12005\n\
 application.name=frontend.war' > /config/bootstrap.properties

--- a/game-service/Dockerfile
+++ b/game-service/Dockerfile
@@ -1,6 +1,6 @@
-FROM openliberty/open-liberty:microProfile1
-ADD build/libs/game-service.war /config/dropins
-COPY src/main/liberty/config /config/
+FROM open-liberty:microProfile1
+ADD --chown=1001:0 build/libs/game-service.war /config/dropins
+COPY --chown=1001:0 src/main/liberty/config /config/
 RUN printf 'httpPort=8080\n\
 httpsPort=8443' > /config/bootstrap.properties
 #RUN printf -- "-Dorg.libertybikes.restclient.PlayerService/mp-rest/url=\

--- a/player-service/Dockerfile
+++ b/player-service/Dockerfile
@@ -1,6 +1,6 @@
-FROM openliberty/open-liberty:microProfile1
-ADD build/libs/player-service.war /config/dropins
-COPY src/main/liberty/config /config/
+FROM open-liberty:microProfile1
+ADD --chown=1001:0 build/libs/player-service.war /config/dropins
+COPY --chown=1001:0 src/main/liberty/config /config/
 RUN printf 'httpPort=8081\n\
 httpsPort=8444' > /config/bootstrap.properties
 


### PR DESCRIPTION
OpenLiberty recently followed other WAS images in converting it to run OL as a non-root user. The Dockerfiles needed to be adjusted to set the correct permissions on the files they add to the image.

Also bringing up the version of OL in the dependencies to match what comes in a modern container image.

We might want to disable the toolchain so merging this doesn't take those servers down if we still want them to remain up.