### PR TITLE
Update player direction before round starts

### DIFF
--- a/game-service/src/main/java/org/libertybikes/game/maps/CrossSlice.java
+++ b/game-service/src/main/java/org/libertybikes/game/maps/CrossSlice.java
@@ -24,6 +24,6 @@ public class CrossSlice extends GameMap {
                                        new Point(GameBoard.BOARD_SIZE / 2 - 15, GameBoard.BOARD_SIZE / 2 + 15),
                                        new Point(GameBoard.BOARD_SIZE / 2 + 15, GameBoard.BOARD_SIZE / 2 + 15)
         };
-        startingDirections = new DIRECTION[] { DIRECTION.UP, DIRECTION.RIGHT, DIRECTION.DOWN, DIRECTION.LEFT };
+        startingDirections = new DIRECTION[] { DIRECTION.UP, DIRECTION.UP, DIRECTION.DOWN, DIRECTION.DOWN };
     }
 }


### PR DESCRIPTION
The reason I stuck most of startGame() in a Runnable is because our 3 second call to delay() would block processing anything else, hitting an arrow key during the '3,2,1,Go' countdown wouldn't have the onMessage() processed until the game started.